### PR TITLE
Fix width of header and footer on the commands page to match main content

### DIFF
--- a/bot/commands.html
+++ b/bot/commands.html
@@ -16,7 +16,7 @@
 </head>
 <body>
     <nav>
-        <div class="wrap">
+        <div class="wrap wide">
             <h2>Bot-chan</h2>
             <ul>
                 <li><a href="index.html">Home</a></li>
@@ -361,7 +361,7 @@
         </table>
     </main>
     <footer>
-        <div class="wrap">
+        <div class="wrap wide">
             <p>Copyright &copy; 2016 <a href="https://brussell98.github.io/">Brandon Russell</a>. Website by <a href="https://geo1088.github.io/">Geo1088</a>.</p>
         </div>
     </footer>

--- a/bot/style.css
+++ b/bot/style.css
@@ -184,7 +184,7 @@ main {
     text-align: center;
     box-shadow: 0 0 0 2px rgba(0,0,0,0.2)
 }
-main.wide {
+.wide {
 	max-width: 1200px;
 }
 main h2 {


### PR DESCRIPTION
The navbar and footer use wrappers of smaller size than the main content which is bad. Fixing via PR because I don't feel like committing to master the proper way
